### PR TITLE
Added support for specifying ulimit in /etc/default/riak on debian/ubuntu.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+default.riak.ulimit = "4096"
 
 include_attribute "riak::package"
 include_attribute "riak::core"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,6 +52,11 @@ package_name = package_file.split("[-_]\d+\.").first
 
 if %w{debian ubuntu}.include?(node[:platform])
   include_recipe "riak::iptables"
+  template "/etc/default/riak" do
+    source "riak.default.erb"
+    owner "root"
+    mode 0644
+  end
 end
 
 group "riak"

--- a/templates/default/riak.default.rb
+++ b/templates/default/riak.default.rb
@@ -1,0 +1,1 @@
+ulimit -n <%= node[:riak][:ulimit] %>


### PR DESCRIPTION
Rather than relying on a third-party cookbook to mess with ulimits, per the documentation at http://wiki.basho.com/Open-Files-Limit.html set the ulimit with a new template at /etc/default/riak.
