### PR TITLE
Iterate over a copy of the riak hash

### DIFF
--- a/libraries/riak_template_helper.rb
+++ b/libraries/riak_template_helper.rb
@@ -63,7 +63,7 @@ module RiakTemplateHelper
     riak.reject! {|k,_| RIAK_REMOVE_CONFIGS.include? k }
 
     # Rename sections
-    riak.each do |k,v|
+    riak.dup.each do |k,v|
       next if k.nil?
       if RIAK_TRANSLATE_CONFIGS.include? k
         riak[RIAK_TRANSLATE_CONFIGS[k]] = riak.delete(k)


### PR DESCRIPTION
In Ruby 1.9.2 replacing a key in a hash while iterating over that hash produces the following error:

```
can't add a new key into hash during iteration (RuntimeError)
```
