### PR TITLE
Riak Core Handoff Port Being Called From KV 

### DIFF
--- a/templates/default/iptables.erb
+++ b/templates/default/iptables.erb
@@ -10,4 +10,4 @@
 -A INPUT -p TCP --dst <%= ip %> --dport <%= port %> -j ACCEPT
 <% end %>
 -A INPUT -p TCP --dst <%= node[:riak][:kv][:pb_ip] %> --dport <%= node[:riak][:kv][:pb_port] %> -j ACCEPT
--A INPUT -p TCP --dst <%= node[:riak][:kv][:pb_ip] %> --dport <%= node[:riak][:kv][:handoff_port] %> -j ACCEPT
+-A INPUT -p TCP --dst <%= node[:riak][:kv][:pb_ip] %> --dport <%= node[:riak][:core][:handoff_port] %> -j ACCEPT


### PR DESCRIPTION
This node attribute is part of core, not KV. See user submitted bug.

https://github.com/basho/riak-chef-cookbook/issues/8
