### PR TITLE
keyless attributes were not getting quoted in app.config.  added to_s to...

### DIFF
--- a/libraries/riak_template_helper.rb
+++ b/libraries/riak_template_helper.rb
@@ -45,7 +45,7 @@ module RiakTemplateHelper
     values = hash.map do |k,v|
       if KEYLESS_ATTRIBUTES.include?(k)
         #We make the assumption that all KEYLESS_ATTRIBUTES are arrays. 
-        Tuple.new(v)
+        Tuple.new(v).to_s
       else
         "{#{k}, #{value_to_erlang(v, depth)}}"
       end


### PR DESCRIPTION
... fix that.

riak startup was bombing on incorrectly formatted log lines in the app.config.  Looks like an overloaded to_s was made in the Tuple class.  Called that to properly output the log lines, and riak starts up with no issues.
