### PR TITLE
Fix mapred_system's default value for pipe (must be a symbol)

### DIFF
--- a/attributes/kv.rb
+++ b/attributes/kv.rb
@@ -19,7 +19,7 @@
 
 default.riak.kv.mapred_queue_dir = "/var/lib/riak/mr_queue"
 default.riak.kv.mapred_name = "mapred"
-default.riak.kv.mapred_system = "pipe"
+default.riak.kv.mapred_system = :pipe
 default.riak.kv.mapred_2i_pipe = true
 default.riak.kv.map_js_vm_count = 8
 default.riak.kv.reduce_js_vm_count = 6


### PR DESCRIPTION
If `mapred_system`'s value in `attribtues/kv.rb` is a string it ends up as `"pipe"` in the config.

`console.log` will show the following:

```
[warning] <0.122.0> Unknown value for riak_kv:mapred_system:
   "pipe"
Defaulting to 'legacy'.
```

If the value is a symbol it'll become `pipe` which is the correct value.
