### PR TITLE
Retry waiting for riak_kv.

### DIFF
--- a/recipes/autoconf.rb
+++ b/recipes/autoconf.rb
@@ -33,6 +33,7 @@ bash "Start riak and wait for riak_kv to be available" do
 #{bin_path}/riak start
 #{bin_path}/riak-admin wait-for-service riak_kv #{node[:riak][:erlang][:node_name]}
 SCRIPT
+  retries 3
   timeout 45
 end
 


### PR DESCRIPTION
For some reason, especially on new installs, the "wait-for-service"
command will sometimes just say "riak_kv is not up: []" even though
if you simply retry the command, it works instantly. The easy workaround
is to retry the block.
