### PR TITLE
Fixes installation failure on Ubuntu 11.10

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,11 +39,8 @@ else
                   when "binary"
                     case node[:platform]
                     when "debian","ubuntu"
-                      if node[:platform_version] == "11.10"
-                        "#{base_filename.gsub(/\-/, '_')}-#{node[:riak][:package][:version][:build]}_ubuntu_11_#{machines[node[:kernel][:machine]]}.deb"
-                      else
-                        "#{base_filename.gsub(/\-/, '_')}-#{node[:riak][:package][:version][:build]}_#{machines[node[:kernel][:machine]]}.deb"
-                      end
+                      package "libssl0.9.8" if node[:platform_version] == "11.10"
+                      "#{base_filename.gsub(/\-/, '_')}-#{node[:riak][:package][:version][:build]}_#{machines[node[:kernel][:machine]]}.deb"
                     when "centos","redhat","suse"
                       if node[:platform_version].to_i == 6
                         "#{base_filename}-#{node[:riak][:package][:version][:build]}.el6.#{machines[node[:kernel][:machine]]}.rpm"


### PR DESCRIPTION
The default recipe for `riak-chef-cookbook` was failing on a Ubuntu 11.10 32bit install because it was trying to install a `.deb` that didn't exist on `downloads.basho.com`.  I adjusted the 11.10 specific condition to install the base `.deb` and `libssl0.9.8`.  After re-running the cookbook from scratch, installation succeeded.
