### PR TITLE
Output configuration in key sorted order

### DIFF
--- a/libraries/riak_template_helper.rb
+++ b/libraries/riak_template_helper.rb
@@ -42,9 +42,14 @@ module RiakTemplateHelper
   def to_erlang_config(hash, depth = 1)
     padding = '    ' * depth
     parent_padding = '    ' * (depth-1)
-    values = hash.map do |k,v|
+
+    # Traverse through the hash in key sorted order so that we avoid
+    # any issues with the traversal order changing and forcing a Riak restart.
+    values = hash.keys.sort.map do |k|
+      v = hash[k]
+
       if KEYLESS_ATTRIBUTES.include?(k)
-        #We make the assumption that all KEYLESS_ATTRIBUTES are arrays. 
+        #We make the assumption that all KEYLESS_ATTRIBUTES are arrays.
         Tuple.new(v).to_s
       else
         "{#{k}, #{value_to_erlang(v, depth)}}"
@@ -52,15 +57,15 @@ module RiakTemplateHelper
     end.join(",\n#{padding}")
     "[\n#{padding}#{values}\n#{parent_padding}]"
   end
-  
-  #There are several configurations that are not key/value. They should be added to KEYLESS_ATTRIBUTES. 
-  #A sample of this wold be the lager configuration. 
+
+  #There are several configurations that are not key/value. They should be added to KEYLESS_ATTRIBUTES.
+  #A sample of this wold be the lager configuration.
   #{"{{platform_log_dir}}/error.log", error, 10485760, "$D0", 5}
   KEYLESS_ATTRIBUTES = ['lager_error_log','lager_console_log','default_user']
-  
-  #Remove these configs. This will make sure package and erlang vms are not processed into the riak app.config. 
+
+  #Remove these configs. This will make sure package and erlang vms are not processed into the riak app.config.
   RIAK_REMOVE_CONFIGS = ['package', 'erlang']
-  
+
   RIAK_TRANSLATE_CONFIGS = {
     'core' => 'riak_core',
     'kv' => 'riak_kv',
@@ -145,7 +150,7 @@ module RiakTemplateHelper
     "smp" => "-smp",
     "env_vars" => "-env"
   }
-    
+
   def prepare_vm_args(config)
     config.map do |k,v|
       key = RIAK_VM_ARGS[k.to_s]


### PR DESCRIPTION
Hash traversal order is undefined in Ruby. I have seen cases where it
actually will change each Chef run, causing the config to change, and
ultimately causing Riak to restart every Chef run. This forces the
configuration to be outputted in key sorted order every time.
