### PR TITLE
Prepare VM arguments using the hash value of node.riak.erlang

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -130,7 +130,7 @@ template "#{node[:riak][:package][:config_dir]}/app.config" do
 end
 
 template "#{node[:riak][:package][:config_dir]}/vm.args" do
-  variables :switches => prepare_vm_args(node[:riak][:erlang])
+  variables :switches => prepare_vm_args(node[:riak][:erlang].to_hash)
   source "vm.args.erb"
   owner "root"
   mode 0644


### PR DESCRIPTION
Since Chef uses "Mashes" which aren't actually Hashes, some of the Riak
configuration turned to strings were "Chef::Node::Attribute" objects.
By calling `to_hash` it turns it into a hash which is what the libraries
expect.
