### PR TITLE
Fixing class type change in new version of Chef

### DIFF
--- a/libraries/riak_template_helper.rb
+++ b/libraries/riak_template_helper.rb
@@ -158,7 +158,7 @@ module RiakTemplateHelper
       case v
       when false
         nil
-      when Hash
+      when Hash, Chef::Node::Attribute
         # Mostly for env_vars
         v.keys.sort.map { |ik| "#{key} #{ik} #{v[ik]}" }
       else


### PR DESCRIPTION
Nested hash's are now namespaced as Chef::Node::Attribute instead of Hash. I simply added another class to check for.
