### PR TITLE
Made the Erlang node name, http, https, and pb_ip's use real node IP addresses and hostname.

### DIFF
--- a/attributes/core.rb
+++ b/attributes/core.rb
@@ -31,7 +31,8 @@ else
   default.riak.core.platform_lib_dir = "/usr/lib/riak"
 end
 
-default.riak.core.http = [["127.0.0.1",8098]]
+default.riak.core.http = [[node['cloud']['local_ipv4'] || node['ipaddress'], 8098]]
+default.riak.core.https = [[node['cloud']['local_ipv4'] || node['ipaddress'], 8096]]
 default.riak.core.ring_state_dir = "/var/lib/riak/ring"
 default.riak.core.handoff_port = 8099
 default.riak.core.cluster_name = "default"

--- a/attributes/erlang.rb
+++ b/attributes/erlang.rb
@@ -19,7 +19,7 @@
 
 include_attribute "riak::core"
 
-default.riak.erlang.node_name = "riak@127.0.0.1"
+default.riak.erlang.node_name = node['hostname'] + "@" + node['cloud']['local_ipv4'] || node['ipaddress']
 default.riak.erlang.cookie = "riak"
 default.riak.erlang.kernel_polling = true
 default.riak.erlang.async_threads = 64

--- a/attributes/kv.rb
+++ b/attributes/kv.rb
@@ -32,6 +32,6 @@ default.riak.kv.riak_kv_stat = true
 default.riak.kv.legacy_stats = true
 default.riak.kv.vnode_vclocks = true
 default.riak.kv.legacy_keylisting = false
-default.riak.kv.pb_ip = "127.0.0.1"
+default.riak.kv.pb_ip = node['cloud']['local_ipv4'] || node['ipaddress']
 default.riak.kv.pb_port = 8087
 default.riak.kv.storage_backend = :riak_kv_bitcask_backend

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -24,7 +24,7 @@ if (node.riak.package.type.eql?("source"))
 end
 
 # erlang.rb
-node.default.riak.erlang.node_name = "riak@#{node.ipaddress}"
+node.default.riak.erlang.node_name = node['hostname'] + "@" + node['cloud']['local_ipv4'] || node['ipaddress']
 
 # core.rb
 # Make sure the bare minimums are set so the cluster works

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ else
                   when "binary"
                     case node[:platform]
                     when "debian","ubuntu"
-                      package "libssl0.9.8" if node[:platform_version] == "11.10"
+                      package "libssl0.9.8"
                       "#{base_filename.gsub(/\-/, '_')}-#{node[:riak][:package][:version][:build]}_#{machines[node[:kernel][:machine]]}.deb"
                     when "centos","redhat","suse"
                       if node[:platform_version].to_i == 6
@@ -130,7 +130,7 @@ template "#{node[:riak][:package][:config_dir]}/app.config" do
 end
 
 template "#{node[:riak][:package][:config_dir]}/vm.args" do
-  variables :switches => prepare_vm_args(node[:riak][:erlang].to_hash)
+  variables :switches => prepare_vm_args(node[:riak][:erlang])
   source "vm.args.erb"
   owner "root"
   mode 0644


### PR DESCRIPTION
This is necessary for the node to do anything useful by default in a typical chef environment (ie, any actual cluster).  

If for some reason you wanted to have those things set as riak@127.0.0.1 and 127.0.0.1 then you could easily do that by masking Role overrides onto the Recipe defaults.  

This makes a lot more sense than doing it the other way around because Roles can't introspect Node metadata dynamically, but Recipes can.  The real IP and hostname are dynamic per Node.  127.0.0.1 is a statically known value, likeswise for "riak" as an erlang name.
