### PR TITLE
Add a monit recipe to monitor and restart riak, for use in conjunction with the monit cookbook

### DIFF
--- a/attributes/monit.rb
+++ b/attributes/monit.rb
@@ -1,0 +1,4 @@
+default.riak.monit.process_matching = "/usr/lib/riak/erts-5.8.5/bin/beam.smp"
+default.riak.monit.start_program = "/usr/sbin/riak"
+default.riak.monit.http_host = "localhost"
+default.riak.monit.http_port = "8098"

--- a/recipes/monit.rb
+++ b/recipes/monit.rb
@@ -1,0 +1,14 @@
+# This is an optional recipe that provides monit monitoring of your riak node. Requires the monit cookbook.
+
+include_recipe "monit::default"
+
+monitrc "riak" do
+  variables(
+    :process_matching => node[:riak][:monit][:process_matching],
+    :start_program => node[:riak][:monit][:start_program],
+    :http_host => node[:riak][:monit][:http_host],
+    :http_port => node[:riak][:monit][:http_port]
+  )
+  template_source "riak-monit.conf.erb"
+  template_cookbook "riak"
+end

--- a/templates/default/riak-monit.conf.erb
+++ b/templates/default/riak-monit.conf.erb
@@ -1,0 +1,7 @@
+check process riak matching "<%= @process_matching %>"
+  group riak
+  start program = "<%= @start_program %>"
+  if failed host <%= @http_host %> port <%= @http_port %> protocol http
+    and request "/"
+    with timeout 2 seconds for 2 cycles
+  then restart


### PR DESCRIPTION
Monit implementation has its own recipe, so it will not affect any nodes that do not specifically add it to their run list.
