### PR TITLE
Stop using DelegateClass

### DIFF
--- a/libraries/riak_template_helper.rb
+++ b/libraries/riak_template_helper.rb
@@ -18,7 +18,7 @@
 #
 require 'delegate'
 module RiakTemplateHelper
-  class Tuple < DelegateClass(Array)
+  class Tuple < Array
     include RiakTemplateHelper
     def to_s
       "{" << map {|i| value_to_erlang(i) }.join(", ") << "}"


### PR DESCRIPTION
Getting rid of the DelegateClass call because it gets double loaded and causes problems with other Riak/RiakCS cookbooks.
