### PR TITLE
Wrong package url when installing from source

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ case node['riak']['package']['type']
       node['riak']['config']['riak_core']['platform_lib_dir'] = "/usr/lib64/riak".to_erl_string if node['kernel']['machine'] == 'x86_64'
     end
   when "source"
-    package_file = "#{base_filename.sub(/\-/, '_')}.tar.gz"
+    package_file = "#{base_filename}.tar.gz"
     node['riak']['package']['prefix'] = "/usr/local"
     node['riak']['package']['config_dir'] = node['riak_eds']['package']['prefix'] + "/riak/etc"
   end


### PR DESCRIPTION
Hi guys,

I was trying to install riak from source using your cookbook and got this error (ubuntu precise):

https://gist.github.com/3845225

Basically, the recipe creates the following url:

```
http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.0/riak_1.2.0.tar.gz
```

Which doesn't exist. I looked into your [downloads](http://basho.com/resources/downloads/) page and the url should be:

```
http://s3.amazonaws.com/downloads.basho.com/riak/1.2/1.2.0/riak-1.2.0.tar.gz
```

The difference is in the name of the file: `-` instead of `_`.

On another note, I had to include `package "erlang-reltool"` for it to work. Is this something that should be included in the default recipe, or should it actually be in the erlang cookbook?

Thanks,
  Carlos
