### PR TITLE
Add name to metadata, start action to service

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+name              "riak"
 maintainer        "Basho Technologies, Inc."
 maintainer_email  "riak@basho.com"
 license           "Apache 2.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,7 +117,7 @@ end
 
 service "riak" do
   supports :start => true, :stop => true, :restart => true
-  action [ :enable ]
+  action [ :enable, :start ]
   subscribes :restart, resources(:file => [ "#{node['riak']['package']['config_dir']}/app.config",
                                    "#{node['riak']['package']['config_dir']}/vm.args" ])
 end


### PR DESCRIPTION
As discussed with Seth, to better interoperate with development tools
like Berkshelf and Test Kitchen, the metadata should have the name of
the cookbook as the "name" attribute. Also, so that this works with
riak-cs properly, the :start action should be specified for the riak
service.
