### PR TITLE
Added support for setting file descriptor limits

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -154,5 +154,8 @@ default['riak']['config']['riak_control']['auth'] = "userlist"
 default['riak']['config']['riak_control']['userlist'] = [["user".to_erl_string,"pass".to_erl_string].to_erl_tuple]
 default['riak']['config']['riak_control']['admin'] = true
 
+# limits
+default['riak']['limits']['nofile'] = 4096
+
 #patches
 default['riak']['patches'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -23,14 +23,13 @@ maintainer_email  "riak@basho.com"
 license           "Apache 2.0"
 description       "Installs and configures Riak distributed data store"
 version           "1.3.1"
-depends           "apt"
-depends           "yum"
-depends           "build-essential"
-depends           "erlang"
 
 recipe            "riak", "Installs Riak from a package"
 recipe            "riak::source", "Installs Erlang and Riak from source"
 
+%w{apt yum build-essential erlang ulimit}.each do |d|
+  depends d
+end
 
 %w{ubuntu debian centos redhat fedora}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe "ulimit"
 
 version_str = "#{node['riak']['package']['version']['major']}.#{node['riak']['package']['version']['minor']}"
 base_uri = "#{node['riak']['package']['url']}/#{version_str}/#{version_str}.#{node['riak']['package']['version']['incremental']}/"
@@ -105,6 +106,10 @@ file "#{node['riak']['package']['config_dir']}/vm.args" do
   owner "root"
   mode 0644
   notifies :restart, "service[riak]"
+end
+
+user_ulimit "riak" do
+  filehandle_limit node['riak']['limits']['nofile']
 end
 
 node['riak']['patches'].each do |patch|


### PR DESCRIPTION
Support for adding file descriptor limits is achieved via the [ulimit](http://community.opscode.com/cookbooks/ulimit) cookbook. The `include_recipe` bit is required to template `/etc/pam.d/su` so that Riak's init scripts can leverage the newly set file descriptor limit.

This pull request aims to resolve #26.
