### PR TITLE
riak_kv_stat should be an attribute, default to 'false'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -93,6 +93,7 @@ default['riak']['config']['riak_kv']['http_url_encoding'] = "on"
 default['riak']['config']['riak_kv']['vnode_vclocks'] = true
 default['riak']['config']['riak_kv']['listkeys_backpressure'] = true
 default['riak']['config']['riak_kv']['vnode_mailbox_limit'] = [1, 5000].to_erl_tuple
+default['riak']['config']['riak_kv']['riak_kv_stat'] = true
 
 # riak_kv storage_backend
 default['riak']['config']['riak_kv']['storage_backend'] = "riak_kv_bitcask_backend"

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -14,4 +14,13 @@ describe "riak::default" do
   it "responds to riak ping" do
     assert(`riak ping` =~ /pong/)
   end
+
+  it "emits riak stats" do
+    if node['riak']['config']['riak_kv']['riak_kv_stat']
+      response = Net::HTTP.get_response(URI.parse("http://#{node['ipaddress']}:8098/stats"))
+      assert(response.body =~ /sys_system_version/)
+    else
+      assert(true)
+    end
+  end
 end


### PR DESCRIPTION
For monitoring via HTTP API endpoint
