### PR TITLE
Ensure that the Riak group is created as a system group

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -27,7 +27,9 @@ include_recipe "git"
 include_recipe "build-essential"
 include_recipe "erlang::source"
 
-group "riak"
+group "riak" do
+  system true
+end
 
 user "riak" do
   gid "riak"


### PR DESCRIPTION
Our packages for Riak create system users and groups for the `riak` service. When compiling from source, the creation of these users and groups is left up to Chef.

While the `riak` user was being created as a system user via the `source` recipe, the `riak` group wasn't. This pull request resolves that.

See https://github.com/basho/riak-cs-chef-cookbook/pull/19 for a similar issue.
