### PR TITLE
Fixes support for older version installs via source and package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,26 @@ suites:
   - recipe[minitest-handler]
   - recipe[riak]
   attributes: {}
+- name: default13
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          minor: 3
+          incremental: 2
+- name: default12
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          minor: 2
+          incremental: 1
 - name: enterprise
   run_list:
   - recipe[minitest-handler]
@@ -34,8 +54,50 @@ suites:
     riak:
       package:
         enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
+- name: enterprise13
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          minor: 3
+          incremental: 2
+        enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
+- name: enterprise12
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          minor: 2
+          incremental: 1
+        enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>
 - name: source
   run_list:
   - recipe[minitest-handler]
   - recipe[riak::source]
   attributes: {}
+- name: source13
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak::source]
+  attributes:
+    riak:
+      source:
+        version:
+          minor: 3
+          incremental: 2
+- name: source12
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak::source]
+  attributes:
+    riak:
+      source:
+        version:
+          minor: 2
+          incremental: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.2.1:
+
+* Fixed package installation so that it respects version numbers.
+
 ## v2.2.0:
 
 * Riak `1.4.0` is the default.

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -58,7 +58,7 @@ else
 
     package "riak" do
       action :install
-      version package_version
+      version (package_version == "1.3.2-1" ? package_version.gsub(/-/, "~precise") : package_version)
     end
 
   when "centos", "redhat"
@@ -79,7 +79,7 @@ else
 
     package "riak" do
       action :install
-      version package_version
+      version "#{package_version}.el#{node['platform_version'].to_i}"
     end
 
   when "fedora"


### PR DESCRIPTION
A few fixes and tests to support older version installs introduced in https://github.com/basho/riak-chef-cookbook/pull/79.
