### PR TITLE
Add recipe-tester.com support

### DIFF
--- a/.recipe-tester.json
+++ b/.recipe-tester.json
@@ -1,0 +1,13 @@
+{
+    "type": "chef-solo",
+    "chef_version": "11.4.4",
+    "ami": [
+        "ami-e7582d8e" // Ubuntu 12.04
+        //"ami-1d620e74" // Debian 7.0.0 - Commenting out for now due to http://tickets.opscode.com/browse/CHEF-4125
+    ],
+    "run_list": [
+        "recipe[riak]"
+    ],
+    "node_attributes": {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Riak Cookbook
 =============
+[![Build Status](https://recipe-tester.com/repo/basho/riak-chef-cookbook/badge.png)](https://recipe-tester.com/repo/basho/riak-chef-cookbook/)
 [![Build Status](https://travis-ci.org/basho/riak-chef-cookbook.png)](https://travis-ci.org/basho/riak-chef-cookbook)
 
 Overview


### PR DESCRIPTION
This adds a configuration file for [Recipe Tester](https://www.recipe-tester.com). Recipe Tester is a hosted continuous integration system for Chef cookbooks. It's like Travis-CI, but for Chef cookbooks.

You'll also need to add a Github post-receive hook for this to work. More info in the [docs](http://docs.recipe-tester.com/).

I've haven't added the CentOS AMIs to the config since I'm having some difficulty with them, but that will hopefully be solved soon.

The build that my fork is running on can be found [here](https://www.recipe-tester.com/repo/spulec/riak-chef-cookbook/).

Please let me know if there are any issues or there's anything else I can do to help get this setup.
