### PR TITLE
Allow users to pass a checksum for the Enterprise package

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,12 @@ platforms:
       memory: 512
   run_list:
   - recipe[apt]
+  attributes:
+    riak:
+      package:
+        checksum:
+          ubuntu:
+            precise: "3f29736ab0dc8b094272d9caefed4e795ae293f54f79bed8d0464ca821c865ef"
 - name: debian-7.1.0
   driver_config:
     box: opscode-debian-7.1.0
@@ -20,6 +26,12 @@ platforms:
       memory: 512
   run_list:
   - recipe[apt]
+  attributes:
+    riak:
+      package:
+        checksum:
+          debian:
+            "7": "7badc4cf084d3a84bbc3c25e206648216e5262d268ea647c438411822c7ae77a"
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4
@@ -29,6 +41,12 @@ platforms:
       memory: 512
   run_list:
   - recipe[yum::epel]
+  attributes:
+    riak:
+      package:
+        checksum:
+          centos:
+            "6": "a2234d09bdbf08da8b9bf5627b4ea718772fc4964c4d59bd3d4c8ada83d5a9f1"
 - name: centos-5.9
   driver_config:
     box: opscode-centos-5.9
@@ -38,6 +56,12 @@ platforms:
       memory: 512
   run_list:
   - recipe[yum::epel]
+  attributes:
+    riak:
+      package:
+        checksum:
+          centos:
+            "5": "d75f0a548b586b327186aba93943aabec0fb51f5ea2acf48de8a5d0a26fea9d7"
 suites:
 - name: default
   run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add a default `cluster_mgr` attribute.
 * Add `allow_mult` override when the `riak_cs_kv_multi_backend` is chosen.
+* Fixed the `remote_file` resource for Enterprise packages so that it utilizes
+  a checksum.
 
 ## v2.3.1:
 


### PR DESCRIPTION
The `checksum` attribute of the `remote_file` resource prevents the package from being re-downloaded if it already exists in the Chef cache. This pull request allows users to provide a checksum namespaced under `platform` (`debian`, `ubuntu`, `centos`) and `platform_version` (`7`, `precise`, `6`).

For example:

``` ruby
# Riak Enterprise 1.4.1 on Ubuntu 12.04
node['riak']['package']['checksum']['ubuntu']['precise'] = "3f29736ab0dc8b094272d9caefed4e795ae293f54f79bed8d0464ca821c865ef"
# Riak Enterprise 1.4.1 on CentOS 6.4
node['riak']['package']['checksum']['centos']['6'] = "a2234d09bdbf08da8b9bf5627b4ea718772fc4964c4d59bd3d4c8ada83d5a9f1"
```
