### PR TITLE
Tired of waiting for the Omnibus installer to download

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,11 @@ platforms:
   driver_config:
     box: opscode-ubuntu-12.04
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-    require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:
@@ -21,7 +25,11 @@ platforms:
   driver_config:
     box: opscode-debian-7.1.0
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_debian-7.1.0_provisionerless.box
-    require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:
@@ -36,7 +44,11 @@ platforms:
   driver_config:
     box: opscode-centos-6.4
     box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-    require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:
@@ -51,7 +63,11 @@ platforms:
   driver_config:
     box: opscode-centos-5.9
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
-    require_chef_omnibus: true
+    require_chef_omnibus: "11.6.0"
+    chef_omnibus_url: https://gist.github.com/hectcastro/6443633/raw/install.sh
+    # Requires a patched version of kitchen-vagrant:
+    # https://github.com/hectcastro/kitchen-vagrant/compare/hc-cachier
+    use_cachier_plugin: true
     customize:
       memory: 512
   run_list:


### PR DESCRIPTION
An experimental pull request.

I got tried of waiting for the Omnibus installer to download on the provisionerless Bento boxes. To remedy that, this pull request:
- Replaces the default `install.sh` script with https://gist.github.com/hectcastro/6443633
- Ensures that `require_chef_omnibus` is set to a specific version of Chef and not a boolean
- Adds a `use_cachier_plugin` item via https://github.com/opscode/kitchen-vagrant/pull/37

Results **without** this patch:

``` bash
       Finished converging <default-ubuntu-1204> (1m20.29s).
-----> Setting up <default-ubuntu-1204>
       Finished setting up <default-ubuntu-1204> (0m0.00s).
-----> Verifying <default-ubuntu-1204>
       Finished verifying <default-ubuntu-1204> (0m0.00s).
-----> Destroying <default-ubuntu-1204>
       [kitchen::driver::vagrant command] BEGIN (vagrant destroy -f)
       [default] Forcing shutdown of VM...
       [default] Destroying VM and associated drives...
       [kitchen::driver::vagrant command] END (0m6.58s)
       Vagrant instance <default-ubuntu-1204> destroyed.
       Finished destroying <default-ubuntu-1204> (0m7.16s).
       Finished testing <default-ubuntu-1204> (2m14.59s).
-----> Kitchen is finished. (2m15.02s)
```

Results **with** this patch:

``` bash
       Finished converging <default-ubuntu-1204> (0m57.85s).
-----> Setting up <default-ubuntu-1204>
       Finished setting up <default-ubuntu-1204> (0m0.00s).
-----> Verifying <default-ubuntu-1204>
       Finished verifying <default-ubuntu-1204> (0m0.00s).
-----> Destroying <default-ubuntu-1204>
       [kitchen::driver::vagrant command] BEGIN (vagrant destroy -f)
       [default] Forcing shutdown of VM...
       [default] Destroying VM and associated drives...
       [kitchen::driver::vagrant command] END (0m6.16s)
       Vagrant instance <default-ubuntu-1204> destroyed.
       Finished destroying <default-ubuntu-1204> (0m6.72s).
       Finished testing <default-ubuntu-1204> (1m54.40s).
-----> Kitchen is finished. (1m54.85s)
```
