### PR TITLE
Update yum_repository resource to v3.0

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -69,17 +69,11 @@ else
   when "centos", "redhat"
     include_recipe "yum"
 
-    yum_key "RPM-GPG-KEY-basho" do
-      url "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
-      action :add
-    end
-
     yum_repository "basho" do
-      repo_name "basho"
       description "Basho Stable Repo"
-      url "http://yum.basho.com/el/#{platform_version}/products/x86_64/"
-      key "RPM-GPG-KEY-basho"
-      action :add
+      baseurl "http://yum.basho.com/el/#{platform_version}/products/x86_64/"
+      gpgkey "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
+      action :create
     end
 
     if platform_version >= 6


### PR DESCRIPTION
This cookbook depends on yum cookbook without locking it to a
version. It also depends on the erlang cookbook which locks yum to >
v3.0. This change is therefore required to install riak on centos boxes.
