### PR TITLE
Convert cookbook to use opscode yum 3.x/yum-epel cookbooks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,7 +40,7 @@ platforms:
     customize:
       memory: 512
   run_list:
-  - recipe[yum::epel]
+  - recipe[yum-epel]
   attributes:
     riak:
       package:
@@ -55,7 +55,7 @@ platforms:
     customize:
       memory: 512
   run_list:
-  - recipe[yum::epel]
+  - recipe[yum-epel]
   attributes:
     riak:
       package:

--- a/Berksfile
+++ b/Berksfile
@@ -4,6 +4,7 @@ metadata
 
 group :integration do
   cookbook "apt"
-  cookbook "yum", "< 3.0"
+  cookbook "yum", "~> 3.0"
+  cookbook "yum-epel", "~> 0.3"
   cookbook "minitest-handler"
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -31,7 +31,7 @@ recipe            "riak::source", "Installs Erlang and Riak from source"
   depends d
 end
 
-depends "yum", "< 3.0"
+depends "yum", "~> 3.0"
 
 %w{ubuntu debian centos redhat fedora}.each do |os|
   supports os

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -69,16 +69,10 @@ else
   when "centos", "redhat"
     include_recipe "yum"
 
-    yum_key "RPM-GPG-KEY-basho" do
-      url "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
-      action :add
-    end
-
     yum_repository "basho" do
-      repo_name "basho"
       description "Basho Stable Repo"
       url "http://yum.basho.com/el/#{platform_version}/products/x86_64/"
-      key "RPM-GPG-KEY-basho"
+      gpgkey "http://yum.basho.com/gpg/RPM-GPG-KEY-basho"
       action :add
     end
 


### PR DESCRIPTION
Converted cookbook to use the yum 3.x cookbook.

Changed yum::epel to yum-epel in .kitchen.yml
