### PR TITLE
Make all cookbook dependency versions explicit

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -27,11 +27,14 @@ version           "2.4.6"
 recipe            "riak", "Installs Riak from a package"
 recipe            "riak::source", "Installs Erlang and Riak from source"
 
-%w{apt build-essential erlang git sysctl ulimit}.each do |d|
-  depends d
-end
-
+depends "apt", "~> 2.3.8"
+depends "build-essential", "~> 1.4.2"
+depends "erlang", "~> 1.5.0"
+depends "git", "~> 3.0"
+depends "sysctl", "~> 0.3.5"
+depends "ulimit", "~> 0.3.2"
 depends "yum", "~> 3.0"
+depends "yum-epel", "~> 0.3"
 
 %w{ubuntu debian centos redhat fedora}.each do |os|
   supports os


### PR DESCRIPTION
- [x] Test Riak on Ubuntu, Debian, CentOS 5/6
- [x] Test Riak Enterprise on Ubuntu, Debian, CentOS 5/6
