### PR TITLE
Ensure /etc/default/riak is regenerated on Debian/Ubuntu platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ if node['platform_family'] == "debian"
     content "ulimit -n #{node['riak']['limits']['nofile']}"
     owner "root"
     mode 0644
-    action :create_if_missing
+    action :create
     notifies :restart, "service[riak]"
   end
 else


### PR DESCRIPTION
Fixes #119
