### PR TITLE
Create platform_etc_dir if it does not already exist.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,11 @@ else
   include_recipe "riak::enterprise_package"
 end
 
+directory "#{node["riak"]["platform_etc_dir"]}" do
+  owner "root"
+  mode 0755
+end
+
 file "#{node["riak"]["platform_etc_dir"]}/riak.conf" do
   content Cuttlefish.compile("", node["riak"]["config"]).join("\n")
   owner "root"


### PR DESCRIPTION
Hi @hectcastro

Before this fix if `platform_etc_dir` was configured to something that does not already exist (e.g. `/etc/riak`) then there is an error on attempting to create `riak.conf` in a parent directory that does not exist
(e.g. `/etc/riak/riak.conf`).

Thanks!
