### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,50 @@
+---
+driver:
+  name: ec2
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  aws_ssh_key_id: <%= ENV["AWS_KEYPAIR_NAME"] %>
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: latest
+
+platforms:
+- name: amazon-2014.03.1
+  driver:
+    image_id: ami-ed8e9284
+    username: ec2-user
+    ssh_key: <%= ENV["EC2_SSH_KEY_PATH"] %>
+  run_list:
+  - recipe[sudo]
+  attributes:
+    riak:
+      package:
+        checksum:
+          amazon:
+            "2014": "2cf9f2481409d2871a6d453a9287f317bd4f5c1cb2e49432f4fee0ac106af56c"
+
+suites:
+- name: default
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          major: 1
+          minor: 4
+          incremental: 8
+- name: enterprise
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[riak]
+  attributes:
+    riak:
+      package:
+        version:
+          major: 1
+          minor: 4
+          incremental: 8
+        enterprise_key: <%= (ENV["RIAK_ENTERPRISE_KEY"].nil? ? "" : ENV["RIAK_ENTERPRISE_KEY"]) %>

--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,7 @@ metadata
 
 group :integration do
   cookbook "apt"
-  cookbook "yum", "~> 3.0"
-  cookbook "yum-epel", "~> 0.3"
+  cookbook "yum"
+  cookbook "sudo"
   cookbook "minitest-handler"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem "foodcritic", "~> 3.0"
 group :integration do
   gem "test-kitchen", "~> 1.0"
   gem "kitchen-vagrant", "~> 0.11"
+  gem "kitchen-ec2", "~> 0.8.0"
 end

--- a/recipes/enterprise_package.rb
+++ b/recipes/enterprise_package.rb
@@ -21,7 +21,8 @@
 version_str = "#{node['riak']['package']['version']['major']}.#{node['riak']['package']['version']['minor']}.#{node['riak']['package']['version']['incremental']}"
 base_uri = "http://private.downloads.basho.com/riak_ee/#{node['riak']['package']['enterprise_key']}/#{version_str}/"
 base_filename = "riak-ee-#{version_str}"
-checksum_val = node['riak']['package']['checksum'][node['platform']][node['platform_version']]
+platform_version = node['platform_version'].to_i
+checksum_val = node['riak']['package']['checksum'][node['platform']][platform_version]
 
 case node['platform']
 when "ubuntu"
@@ -31,17 +32,23 @@ when "ubuntu"
   package_file = "#{base_filename.gsub(/\-/, '_').sub(/_/,'-')}-#{node['riak']['package']['version']['build']}_#{machines[node['kernel']['machine']]}.deb"
 when "debian"
   machines = {"x86_64" => "amd64", "i386" => "i386", "i686" => "i386"}
-  base_uri = "#{base_uri}#{node['platform']}/#{node['platform_version'].to_i}/"
+  base_uri = "#{base_uri}#{node['platform']}/#{platform_version}/"
   package_file = "#{base_filename.gsub(/\-/, '_').sub(/_/,'-')}-#{node['riak']['package']['version']['build']}_#{machines[node['kernel']['machine']]}.deb"
-when "redhat","centos"
+when "redhat","centos", "amazon"
+  if node['platform'] == "amazon" && platform_version >= 2013
+    platform_version = 6
+  elsif node['platform'] == "amazon"
+    platform_version = 5
+  end
+
   machines = {"x86_64" => "x86_64", "i386" => "i386", "i686" => "i686"}
-  base_uri = "#{base_uri}rhel/#{node['platform_version'].to_i}/"
-  package_file = "#{base_filename}-#{node['riak']['package']['version']['build']}.el#{node['platform_version'].to_i}.#{machines[node['kernel']['machine']]}.rpm"
+  base_uri = "#{base_uri}rhel/#{platform_version}/"
+  package_file = "#{base_filename}-#{node['riak']['package']['version']['build']}.el#{platform_version}.#{machines[node['kernel']['machine']]}.rpm"
   node.set['riak']['config']['riak_core']['platform_lib_dir'] = "/usr/lib64/riak".to_erl_string if node['kernel']['machine'] == 'x86_64'
 when "fedora"
   machines = {"x86_64" => "x86_64", "i386" => "i386", "i686" => "i686"}
-  base_uri = "#{base_uri}#{node['platform']}/#{node['platform_version'].to_i}/"
-  package_file = "#{base_filename}-#{node['riak']['package']['version']['build']}.fc#{node['platform_version'].to_i}.#{node['kernel']['machine']}.rpm"
+  base_uri = "#{base_uri}#{node['platform']}/#{platform_version}/"
+  package_file = "#{base_filename}-#{node['riak']['package']['version']['build']}.fc#{platform_version}.#{node['kernel']['machine']}.rpm"
   node.set['riak']['config']['riak_core']['platform_lib_dir'] = "/usr/lib64/riak".to_erl_string if node['kernel']['machine'] == 'x86_64'
 end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -66,8 +66,14 @@ else
       version package_version
     end
 
-  when "centos", "redhat"
+  when "centos", "redhat", "amazon"
     include_recipe "yum"
+
+    if node['platform'] == "amazon" && platform_version >= 2013
+      platform_version = 6
+    elsif node['platform'] == "amazon"
+      platform_version = 5
+    end
 
     yum_repository "basho" do
       description "Basho Stable Repo"


### PR DESCRIPTION
This pull request depends on the changes in https://github.com/basho/riak-chef-cookbook/pull/128. It is also a squashed version of https://github.com/basho/riak-chef-cookbook/pull/126 with `.kitchen.cloud.yml`.

Tests can be run using the following commands:

``` bash
$ KITCHEN_YAML=.kitchen.cloud.yml kitchen test default-amazon-2014031
$ RIAK_ENTERPRISE_KEY="******" KITCHEN_YAML=.kitchen.cloud.yml kitchen test enterprise-amazon-2014031
```
