### PR TITLE
Revert errant change of Riak node name from FQDN to IP address

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['riak']['lib_dir'] = "/usr/lib/riak"
 default['riak']['log_dir'] = "/var/log/riak"
 
 # vm.args
-default['riak']['args']['-name'] = "riak@#{node['ipaddress']}"
+default['riak']['args']['-name'] = "riak@#{node['fqdn']}"
 default['riak']['args']['-setcookie'] = "riak"
 default['riak']['args']['+K'] = true
 default['riak']['args']['+A'] = 64


### PR DESCRIPTION
See: https://github.com/basho/riak-chef-cookbook/commit/faa8e92a12185db379a829ee2010434b011629d9#commitcomment-6190642
