### PR TITLE
Multi backend definitions must be Erlang binaries, not atoms

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -117,9 +117,9 @@ case node['riak']['config']['riak_kv']['storage_backend']
   when "riak_kv_eleveldb_backend"
     default['riak']['config']['eleveldb']['data_root'] = "#{node['riak']['data_dir']}/leveldb".to_erl_string
   when "riak_kv_multi_backend"
-    default['riak']['config']['riak_kv']['multi_backend_default'] = "bitcask_mult"
-    bitcask_mult = ["bitcask_mult", "riak_kv_bitcask_backend", {"data_root" => "#{node['riak']['data_dir']}/bitcask".to_erl_string}]
-    eleveldb_mult = ["eleveldb_mult", "riak_kv_eleveldb_backend", {"data_root" => "#{node['riak']['data_dir']}/leveldb".to_erl_string}]
+    default['riak']['config']['riak_kv']['multi_backend_default'] = "bitcask_mult".to_erl_binary
+    bitcask_mult = ["bitcask_mult".to_erl_binary, "riak_kv_bitcask_backend", {"data_root" => "#{node['riak']['data_dir']}/bitcask".to_erl_string}]
+    eleveldb_mult = ["eleveldb_mult".to_erl_binary, "riak_kv_eleveldb_backend", {"data_root" => "#{node['riak']['data_dir']}/leveldb".to_erl_string}]
     default['riak']['config']['riak_kv']['multi_backend'] = [bitcask_mult.to_erl_tuple, eleveldb_mult.to_erl_tuple]
   when "riak_cs_kv_multi_backend"
     default['riak']['cs_version'] = "1.4.5"


### PR DESCRIPTION
The backends defined in a multi backend configuration should referred to with Erlang binaries. In order to produce an Erlang binary from a Ruby `String`, the `.to_erl_binary` method needs to be called on the `String` literal.

Output of should resemble the `app.config` snippets here: http://docs.basho.com/riak/latest/ops/advanced/backends/multi/#Configuring-Multiple-Backends
