### PR TITLE
Ensure SNMP directory is created when custom data_dir is provided

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,6 +81,15 @@ directory node['riak']['data_dir'] do
   action :create
 end
 
+directory ::File.join(node['riak']['data_dir'], 'snmp', 'agent', 'db') do
+  owner 'riak'
+  group 'riak'
+  mode 0755
+  action :create
+  recursive true
+  not_if { node['riak']['package']['enterprise_key'].empty? }
+end
+
 service "riak" do
   supports :start => true, :stop => true, :restart => true
   action [ :enable, :start ]


### PR DESCRIPTION
The SNMP data directory for Riak gets created by the Riak Enterprise package. When the default data directory for Riak is overwritten via a Chef attribute, this cookbook did not ensure that the SNMP data directory got created.

This pull request ensures that the SNMP data directory gets created within whatever path is specified by `node['riak']['data_dir']`.

---

**Tests**:
- [x] Ensure Riak tests pass
- [x] Ensure Riak Enterprise tests pass
