### PR TITLE
Add support for local package with remote site

### DIFF
--- a/attributes/package.rb
+++ b/attributes/package.rb
@@ -27,3 +27,4 @@ default["riak"]["package"]["version"]["build"] = "1"
 
 default["riak"]["package"]["local"]["filename"] = ""
 default["riak"]["package"]["local"]["checksum"] = ""
+default["riak"]["package"]["local"]["url"] = ""

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -20,6 +20,18 @@
 unless node["riak"]["package"]["local"]["filename"].empty?
   package_file = node["riak"]["package"]["local"]["filename"]
 
+  unless node["riak"]["package"]["local"]["url"].empty?
+    package_uri = "#{node["riak"]["package"]["local"]["url"]}/#{package_file}"
+    checksum_val = node["riak"]["package"]["local"]["checksum"]
+
+    remote_file "#{Chef::Config[:file_cache_path]}/#{package_file}" do
+      source package_uri
+      checksum checksum_val
+      owner "root"
+      mode 0644
+    end
+  end
+
   package node["riak"]["package"]["name"] do
     source "#{Chef::Config[:file_cache_path]}/#{package_file}"
     action :install


### PR DESCRIPTION
I would like to download a package from remote site and install it.
This patch makes sense for us.
