### PR TITLE
remove strict dep versioning for build-essential

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -28,7 +28,7 @@ recipe            "riak", "Installs Riak from a package"
 recipe            "riak::source", "Installs Erlang and Riak from source"
 
 depends "apt", "~> 2.3.8"
-depends "build-essential", "~> 1.4.2"
+depends "build-essential"
 depends "erlang", "~> 1.5.0"
 depends "git", "~> 3.0"
 depends "sysctl", "~> 0.3.5"


### PR DESCRIPTION
refs https://github.com/basho/riak-chef-cookbook/issues/134
