### PR TITLE
Force apt-get to keep the old config file when upgrading Riak

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -64,6 +64,7 @@ else
     package "riak" do
       action :install
       version package_version
+      options '-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"'
     end
 
   when "centos", "redhat", "amazon"


### PR DESCRIPTION
We've ran into this issue when upgrading from Riak 1.4.2 to 1.4.10:

https://gist.github.com/gregkare/8d0dd12d832fc240f701

Adding those dpkg switches enabled us to update.
