### PR TITLE
Change java cookbook to 'suggests' from 'depends'

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -101,6 +101,7 @@ suites:
 - name: search
   run_list:
   - recipe[riak]
+  - recipe[java]
   attributes:
     riak:
       manage_java: true

--- a/Berksfile
+++ b/Berksfile
@@ -7,4 +7,5 @@ group :integration do
   cookbook 'yum'
   cookbook 'freebsd'
   cookbook 'pkg_add', github: 'wanelo-chef/pkg_add'
+  cookbook 'java'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -31,13 +31,14 @@ depends 'apt', '~> 2.3'
 depends 'build-essential', '~> 2.1.2'
 depends 'erlang', '~> 1.5.2'
 depends 'git', '~> 3.0'
-depends 'java', '~> 1.28.0'
 depends 'sysctl', '~> 0.3.5'
 depends 'ulimit', '~> 0.3.2'
 depends 'yum', '~> 3.4'
 depends 'yum-epel', '~> 0.5.1'
 depends 'packagecloud'
 depends 'pkg_add'
+
+suggests 'java', '~> 1.28.0'
 
 %w{ubuntu debian centos redhat fedora amazon freebsd}.each do |os|
   supports os


### PR DESCRIPTION
`riak:java` recipe is optional recipe, and  default value for `riak:manage_java' is `false`.

So, I think `java` cookbook is more appropriate `suggests` rather than `depends` .