### PR TITLE
Fix Riak EE download URL following 2.1 release

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -24,8 +24,14 @@ version_str = %w(major minor incremental).map { |ver| node['riak']['package']['v
 major_minor = %w(major minor).map { |ver| node['riak']['package']['version'][ver] }.join('.')
 package_version = "#{version_str}-#{node['riak']['package']['version']['build']}"
 install_method = node['platform'] == 'freebsd' || oss_or_ee == 'riak-ee' ? 'custom_package' : node['riak']['install_method']
-ee_url_prefix = "http://private.downloads.basho.com/riak_ee/#{node['riak']['package']['enterprise_key']}/#{major_minor}/#{version_str}"
 plat_ver_int = node['platform_version'].to_i
+
+# Enterprise download URL changed with release of 2.1
+if major_minor.to_f >= 2.1
+  ee_url_prefix = "http://private.downloads.basho.com/riak_ee/#{node['riak']['package']['enterprise_key']}/#{major_minor}/#{version_str}"
+else
+  ee_url_prefix = "http://private.downloads.basho.com/riak_ee/#{node['riak']['package']['enterprise_key']}/#{version_str}"
+end
 
 case  install_method
 when 'package', 'custom_repository'


### PR DESCRIPTION
While I'd prefer that #170 be merged, in order to speed things along in case there's concern about the version bump, here's an alternative patch with only the part that fixes the broken Riak EE download URL.

For posterity: The difference between the URLs is that the new one omits the `major_minor` part of the path.